### PR TITLE
feature(portal):implement the portal class

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,5 +1,18 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
+const Portal_1 = __importDefault(require("./lib/Portal"));
+const Service_1 = __importDefault(require("./lib/Service"));
+const services = {
+    userService: new Service_1.default(),
+    paymentService: new Service_1.default(),
+};
+const p = new Portal_1.default(services);
+const { userService } = services;
+userService.connect(p.exposeChannel(userService));
+console.log(userService.channel);
 exports.default = (value) => {
     return value;
 };

--- a/dist/lib/Portal.js
+++ b/dist/lib/Portal.js
@@ -1,0 +1,35 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * A channel through which a service instance can access the other
+ * services held together by the service manager class
+ */
+class Portal {
+    /**
+     *
+     * @param services - A reference to an object containing all the services.
+     */
+    constructor(services) {
+        this.channel = services;
+    }
+    excludeService(serviceToExclude) {
+        const modifiedChannel = {};
+        for (let service in this.channel) {
+            const { value } = Object.getOwnPropertyDescriptor(this.channel, service);
+            if (value !== serviceToExclude) {
+                Object.defineProperty(modifiedChannel, service, { value });
+            }
+        }
+        return modifiedChannel;
+    }
+    /**
+     * Exposes the portal
+     * @param { Service } service - A Service instance.
+     * @returns { object } The reference to the object containing
+     * all the services, but the service, `service`.
+     */
+    exposeChannel(service) {
+        return this.excludeService(service);
+    }
+}
+exports.default = Portal;

--- a/dist/lib/Service.js
+++ b/dist/lib/Service.js
@@ -12,12 +12,12 @@ Object.defineProperty(exports, "__esModule", { value: true });
 class Service {
     /**
      * Allows the service to connect to other services
-     * @param { IPortal } portal - a reference to an object in the service manager containing all other services
+     * @param { IChannel } channel - a reference to an object in the service manager containing all other services
      * in the system except for this current one
      * @returns { void } void
      */
-    connect(portal) {
-        this.portal = portal;
+    connect(channel) {
+        this.channel = channel;
     }
     /**
      * Sets the eventManager through which the service can send and receive

--- a/dist/lib/interfaces/IChannel.js
+++ b/dist/lib/interfaces/IChannel.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -347,6 +347,51 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
+      "integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "4.2.12",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.12.tgz",
@@ -369,6 +414,21 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.3.tgz",
       "integrity": "sha512-vyxR57nv8NfcU0GZu8EUXZLTbCMupIUwy95LJ6lllN+JRPG25CwMHoB1q5xKh8YKhQnHYRAn4yW2yuHbf/5xgg==",
+      "dev": true
+    },
+    "@types/sinon": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.5.tgz",
+      "integrity": "sha512-4CnkGdM/5/FXDGqL32JQ1ttVrGvhOoesLLF7VnTh4KdjK5N5VQOtxaylFqqTjnHx55MnD9O02Nbk5c1ELC8wlQ==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
+      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
       "dev": true
     },
     "acorn": {
@@ -2267,6 +2327,12 @@
         "object.assign": "^4.1.0"
       }
     },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "dev": true
+    },
     "language-subtag-registry": {
       "version": "0.3.20",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.20.tgz",
@@ -2330,6 +2396,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "log-driver": {
@@ -2540,6 +2612,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-preload": {
       "version": "0.2.1",
@@ -2937,6 +3022,23 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -3302,6 +3404,38 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "sinon": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
+      "integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.1.0",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "slice-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.12",
     "@types/mocha": "^8.0.3",
+    "@types/sinon": "^9.0.5",
     "chai": "^4.2.0",
     "coveralls": "^3.1.0",
     "eslint": "^7.7.0",
@@ -20,6 +21,7 @@
     "mocha": "^8.1.2",
     "nyc": "^15.1.0",
     "prettier": "^2.1.1",
+    "sinon": "^9.0.3",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.2"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,19 @@
+import Portal from './lib/Portal';
+import Service from './lib/Service';
+
+const services = {
+  userService: new Service(),
+  paymentService: new Service(),
+};
+
+const p = new Portal(services);
+
+const { userService } = services;
+
+userService.connect(p.exposeChannel(userService));
+
+console.log(userService.channel);
+
 export default (
   value: number | string | boolean
 ): number | string | boolean => {

--- a/src/lib/Portal.ts
+++ b/src/lib/Portal.ts
@@ -1,0 +1,45 @@
+import Service from './Service';
+import IPortal from './interfaces/IPortal';
+import IChannel from './interfaces/IChannel';
+
+/**
+ * A channel through which a service instance can access the other
+ * services held together by the service manager class
+ */
+class Portal implements IPortal {
+  readonly channel: IChannel;
+
+  /**
+   *
+   * @param services - A reference to an object containing all the services.
+   */
+  constructor(services: object) {
+    this.channel = services;
+  }
+
+  excludeService(serviceToExclude: Service): object {
+    let modifiedChannel: IChannel = {};
+
+    for (let service in this.channel) {
+      const { value } = Object.getOwnPropertyDescriptor(this.channel, service)!;
+
+      if (value === serviceToExclude) {
+        modifiedChannel = { ...this.channel, [service]: undefined };
+      }
+    }
+
+    return modifiedChannel;
+  }
+
+  /**
+   * Exposes the portal
+   * @param { Service } service - A Service instance.
+   * @returns { object } The reference to the object containing
+   * all the services, but the service, `service`.
+   */
+  exposeChannel(service: Service): IChannel {
+    return this.excludeService(service);
+  }
+}
+
+export default Portal;

--- a/src/lib/Service.ts
+++ b/src/lib/Service.ts
@@ -1,6 +1,6 @@
 import IService from './interfaces/IService';
 import IEventManager from './interfaces/IEventManager';
-import IPortal from './interfaces/IPortal';
+import IChannel from './interfaces/IChannel';
 
 /**
  * It is the oldest ancestor of all other services of this API and the only place
@@ -11,18 +11,18 @@ import IPortal from './interfaces/IPortal';
  * and reach out to an external API over a network protocol, but must not send
  * a response to the requesting client.
  */
-class Service {
-  protected eventManager: IEventManager | undefined;
-  protected portal: IPortal | undefined;
+class Service implements IService {
+  eventManager: IEventManager | undefined;
+  channel: IChannel | undefined;
 
   /**
    * Allows the service to connect to other services
-   * @param { IPortal } portal - a reference to an object in the service manager containing all other services
+   * @param { IChannel } channel - a reference to an object in the service manager containing all other services
    * in the system except for this current one
    * @returns { void } void
    */
-  connect(portal: IPortal): void {
-    this.portal = portal;
+  connect(channel: IChannel): void {
+    this.channel = channel;
   }
 
   /**

--- a/src/lib/interfaces/IChannel.ts
+++ b/src/lib/interfaces/IChannel.ts
@@ -1,0 +1,3 @@
+type IChannel = object;
+
+export default IChannel;

--- a/src/lib/interfaces/IPortal.ts
+++ b/src/lib/interfaces/IPortal.ts
@@ -5,5 +5,7 @@ export default interface IPortal {
    * An object containing a set of services
    * @property
    */
-  services: object;
+  channel: object;
+
+  exposeChannel(service: IService): object;
 }

--- a/src/lib/interfaces/IService.ts
+++ b/src/lib/interfaces/IService.ts
@@ -1,9 +1,8 @@
 import IEventManager from './IEventManager';
-import IPortal from './IPortal';
 
 export default interface IService {
   eventManager: IEventManager | undefined;
-  portal: IPortal | undefined;
-  connect(portal: IPortal): void;
+  channel: object | undefined;
+  connect(channel: object): void;
   setEventManager(eventManager: IEventManager): void;
 }

--- a/tests/lib/Portal.test.ts
+++ b/tests/lib/Portal.test.ts
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import IChannel from '../../src/lib/interfaces/IChannel';
+import IPortal from '../../src/lib/interfaces/IPortal';
+import Service from '../../src/lib/Service';
+import Portal from '../../src/lib/Portal';
+
+const services = {
+  userService: new Service(),
+  paymentService: new Service(),
+};
+
+describe('Portal', () => {
+  let portal: Portal;
+
+  before(() => {
+    portal = new Portal(services);
+  });
+
+  describe('When the exposeChannel method is called', () => {
+    it('should return a portal channel', () => {
+      expect(typeof portal!.exposeChannel(services.userService)).to.equal(
+        'object'
+      );
+    });
+
+    it('should call the excludeService() method', () => {
+      const excludeServiceMock = sinon.stub(portal!, 'excludeService');
+      const { userService } = services;
+      const modifiedChannel = portal!.exposeChannel(userService);
+
+      expect(excludeServiceMock.calledOnceWith(userService)).is.true;
+    });
+  });
+
+  describe('When the excludeService method is called', () => {
+    it('should return a modified channel that has no access to the service that was passed  to the excludeService as an argument', () => {
+      const services = {
+        postService: new Service(),
+        collectionService: new Service(),
+      };
+
+      const portal = new Portal(services);
+
+      const { postService } = services;
+      const modifiedChannel = portal!.excludeService(postService);
+      const { value } = Object.getOwnPropertyDescriptor(
+        modifiedChannel,
+        'postService'
+      )!;
+
+      expect(value).to.be.undefined;
+    });
+  });
+});

--- a/tests/lib/Services.test.ts
+++ b/tests/lib/Services.test.ts
@@ -2,8 +2,15 @@ import { expect } from 'chai';
 import Service from '../../src/lib/Service';
 import IPortal from '../../src/lib/interfaces/IPortal';
 import IEventManager from '../../src/lib/interfaces/IEventManager';
+import IChannel from '../../src/lib/interfaces/IChannel';
 
-const portal: IPortal = { services: {} };
+const portal: IPortal = {
+  channel: {},
+  exposeChannel(service: Service) {
+    return this.channel;
+  },
+};
+
 const eventManager: IEventManager = { emit: () => null };
 
 class TestService extends Service {
@@ -11,8 +18,8 @@ class TestService extends Service {
     return this.eventManager;
   }
 
-  getPortal(): IPortal | undefined {
-    return this.portal;
+  getChannel(): object | undefined {
+    return this.channel;
   }
 }
 
@@ -32,12 +39,13 @@ describe('Base Service class', () => {
     });
   });
 
-  describe('When the service is connected, the `portal` property', () => {
-    it('should be be defined', () => {
+  describe('When the service is connected, the `channel` property', () => {
+    it('should be defined', () => {
       testService = testService as TestService;
-      testService.connect(portal);
+      const channel: IChannel = portal.exposeChannel(testService);
+      testService.connect(channel);
 
-      expect(testService!.getPortal()!.services).is.not.undefined;
+      expect(testService!.getChannel()).is.not.undefined;
     });
   });
 });


### PR DESCRIPTION
#### What does this PR do?
Implement the `Portal` class and an `IChannel` type.
#### Description of Task to be completed?
- implement the `Portal` class which exposes a channel through
which services can connect to one another

- write unit tests for the methods of the `Portal` class

- update the unit tests of the base service class following
changes to the `Service` class necessitated by the creation of
the `Portal` class

-create an `IChannel` type
#### How should this be manually tested?
- clone the repository.
- cd into the project  directory.
- run `npm install` to install all the project's dependencies.
- run `npm test` to run all  tests
- navigate to the `src` directory and open the `index.ts` file. In there, you can work with a portal and services like so:
```
import Portal from './lib/Portal';
import Service from './lib/Service';

const services = {
  userService: new Service(),
  paymentService: new Service(),
};

const portal = new Portal(services);

const { userService } = services;

userService.connect(portal.exposeChannel(userService));

// Prints an object containing all the services passed to the Portal with the `userService` property set to undefined so that a service should be unable to access itself through the portal's channel.
console.log(userService.channel);
```

The `Portal` class has two main functions
    - allow a service to access the methods of other services by  providing a reference (via the `channel`) to these other service instances.
    - prevent a service from accessing itself through the provided channel

#### Any background context you want to provide?
All of the core modules are in the `/scr/lib` directory.
#### What are the relevant pivotal tracker stories?
#8 
#### Screenshots (if appropriate)
#### Questions: